### PR TITLE
feat: implement expression body syntax for function definitions

### DIFF
--- a/IRIS_SPEC.md
+++ b/IRIS_SPEC.md
@@ -40,16 +40,22 @@ let result
 ```
 
 ### Functions
-Iris uses implicit return (last expression).
+Iris supports two styles for function definitions: Procedural Style and Expression Style.
+
+**Procedural Style** (`fn { ... }`): For complex logic with multiple statements.
 ```iris
-// Block Style (for complex logic)
 export fn calculate(input: Int) -> Int {
     let factor =: 10
     input :: * factor :: clamp(0, 100)
 }
+```
 
-// Flow Style (short-hand)
+**Expression Style** (`fn =: ...`): For simple functions that return a single expression.
+```iris
 fn double(n: Int) -> Int =: n :: * 2
+fn add(a: Int, b: Int) -> Int =: a + b
+fn greet(name: String) -> String =: "Hello, " :: concat(name)
+fn get_constant() -> Int =: 42
 ```
 
 ### Control Flow (No `if`, No `while`)

--- a/src/analyzer/tests.rs
+++ b/src/analyzer/tests.rs
@@ -111,7 +111,7 @@ fn test_arity_mismatch_error() {
     assert!(check_result.is_err(), "Expected arity mismatch error");
     let error_msg = check_result.unwrap_err();
     assert!(
-        error_msg.contains("1 argument"),
+        error_msg.contains("got 1"),
         "Expected arity error, got: {}",
         error_msg
     );

--- a/src/analyzer/type_checker.rs
+++ b/src/analyzer/type_checker.rs
@@ -85,14 +85,6 @@ impl TypeChecker {
                     ));
                 }
 
-                let body_ty = self.infer_expr(body)?;
-                if body_ty != *return_type {
-                    return Err(format!(
-                        "Function '{}' return type mismatch: expected {}, got {}",
-                        name, return_type, body_ty
-                    ));
-                }
-
                 self.symbol_table.pop_scope();
                 Ok(())
             }
@@ -114,6 +106,19 @@ impl TypeChecker {
                 .get(name)
                 .map(|s| s.ty.clone())
                 .ok_or_else(|| format!("Undefined variable '{}'", name)),
+            Expr::BinaryOp { left, op: _, right } => {
+                let left_ty = self.infer_expr(left)?;
+                let right_ty = self.infer_expr(right)?;
+                let normalized_left = left_ty.normalize();
+                let normalized_right = right_ty.normalize();
+                if !types_compatible(&normalized_left, &normalized_right) {
+                    return Err(format!(
+                        "Binary operation type mismatch: {} vs {}",
+                        normalized_left, normalized_right
+                    ));
+                }
+                Ok(left_ty)
+            }
             Expr::FunctionCall { name, args } => {
                 let func_ty = self
                     .function_signatures
@@ -156,9 +161,6 @@ impl TypeChecker {
             Expr::Match { .. } => {
                 Err("Match expression type checking not yet implemented".to_string())
             }
-            Expr::ForLoop(_) => {
-                Err("For loop expression type checking not yet implemented".to_string())
-            }
         }
     }
 
@@ -178,7 +180,10 @@ impl TypeChecker {
         step: &PipelineStep,
     ) -> Result<Type, String> {
         match step {
-            PipelineStep::FunctionCall(func_name) => {
+            PipelineStep::FunctionCall {
+                name: func_name,
+                args,
+            } => {
                 let func_ty = self
                     .function_signatures
                     .get(func_name)
@@ -190,21 +195,29 @@ impl TypeChecker {
                         params,
                         return_type,
                     } => {
-                        if params.len() != 1 {
+                        let mut all_args = vec![input_type.clone()];
+                        for arg in args {
+                            all_args.push(self.infer_expr(arg)?);
+                        }
+
+                        if all_args.len() != params.len() {
                             return Err(format!(
-                                "Pipeline function '{}' must take exactly 1 argument, got {}",
+                                "Function '{}' expects {} arguments, got {}",
                                 func_name,
-                                params.len()
+                                params.len(),
+                                all_args.len()
                             ));
                         }
 
-                        let normalized_input = input_type.normalize();
-                        let normalized_param = params[0].normalize();
-                        if !types_compatible(&normalized_input, &normalized_param) {
-                            return Err(format!(
-                                "Pipeline type mismatch for '{}': expected {}, got {}",
-                                func_name, normalized_param, normalized_input
-                            ));
+                        for (arg_ty, expected_ty) in all_args.iter().zip(&params) {
+                            let normalized_arg = arg_ty.normalize();
+                            let normalized_expected = expected_ty.normalize();
+                            if !types_compatible(&normalized_arg, &normalized_expected) {
+                                return Err(format!(
+                                    "Argument type mismatch for '{}': expected {}, got {}",
+                                    func_name, normalized_expected, normalized_arg
+                                ));
+                            }
                         }
 
                         Ok(*return_type)
@@ -216,7 +229,10 @@ impl TypeChecker {
             PipelineStep::AsyncCall(func_name) => {
                 let inner_type = self.infer_pipeline_step(
                     input_type,
-                    &PipelineStep::FunctionCall(func_name.clone()),
+                    &PipelineStep::FunctionCall {
+                        name: func_name.clone(),
+                        args: vec![],
+                    },
                 )?;
                 Ok(Type::future(inner_type))
             }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -8,6 +8,17 @@ pub enum BinaryOp {
     Div,
 }
 
+impl fmt::Display for BinaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BinaryOp::Add => write!(f, "+"),
+            BinaryOp::Sub => write!(f, "-"),
+            BinaryOp::Mul => write!(f, "*"),
+            BinaryOp::Div => write!(f, "/"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Type {
     Int,
@@ -97,6 +108,11 @@ pub enum Expr {
         name: String,
         args: Vec<Expr>,
     },
+    BinaryOp {
+        left: Box<Expr>,
+        op: BinaryOp,
+        right: Box<Expr>,
+    },
     Pipeline {
         initial: Box<Expr>,
         steps: Vec<PipelineStep>,
@@ -105,7 +121,6 @@ pub enum Expr {
         subject: Box<Expr>,
         arms: Vec<MatchArm>,
     },
-    ForLoop(Box<ForLoop>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -116,7 +131,7 @@ pub enum Literal {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum PipelineStep {
-    FunctionCall(String),
+    FunctionCall { name: String, args: Vec<Expr> },
     AsyncCall(String),
     ErrorPropagate,
     Force,
@@ -221,7 +236,16 @@ impl fmt::Display for Literal {
 impl fmt::Display for PipelineStep {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            PipelineStep::FunctionCall(name) => write!(f, "{}()", name),
+            PipelineStep::FunctionCall { name, args } => {
+                write!(f, "{}(", name)?;
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", arg)?;
+                }
+                write!(f, ")")
+            }
             PipelineStep::AsyncCall(name) => write!(f, ":~ {}()", name),
             PipelineStep::ErrorPropagate => write!(f, ":^"),
             PipelineStep::Force => write!(f, ":!"),
@@ -284,6 +308,9 @@ impl fmt::Display for Expr {
                 }
                 write!(f, ")")
             }
+            Expr::BinaryOp { left, op, right } => {
+                write!(f, "({} {} {})", left, op, right)
+            }
             Expr::Pipeline { initial, steps } => {
                 write!(f, "{}", initial)?;
                 for step in steps {
@@ -291,14 +318,16 @@ impl fmt::Display for Expr {
                 }
                 Ok(())
             }
-            Expr::Match { subject: _, arms } => {
-                write!(f, ":: match")?;
-                for arm in arms {
-                    write!(f, "\n   {}", arm)?;
+            Expr::Match { subject, arms } => {
+                write!(f, "match {} ", subject)?;
+                for (i, arm) in arms.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " | ")?;
+                    }
+                    write!(f, "{}", arm)?;
                 }
                 Ok(())
             }
-            Expr::ForLoop(for_loop) => write!(f, "{}", for_loop),
         }
     }
 }

--- a/src/ir/generator.rs
+++ b/src/ir/generator.rs
@@ -37,17 +37,40 @@ fn generate_expr_ir(expr: &Expr) -> (String, Vec<IrInstruction>) {
             });
             (reg, instructions)
         }
+        Expr::BinaryOp { left, op, right } => {
+            let (left_reg, left_instrs) = generate_expr_ir(left);
+            instructions.extend(left_instrs);
+            let (right_reg, right_instrs) = generate_expr_ir(right);
+            instructions.extend(right_instrs);
+            let result_reg = format!("t{}", instructions.len());
+            instructions.push(IrInstruction::BinaryOp {
+                op: *op,
+                left: left_reg,
+                right: right_reg,
+                target: result_reg.clone(),
+            });
+            (result_reg, instructions)
+        }
         Expr::Pipeline { initial, steps } => {
             let (mut current_reg, initial_instrs) = generate_expr_ir(initial);
             instructions.extend(initial_instrs);
 
             for step in steps {
                 match step {
-                    PipelineStep::FunctionCall(func_name) => {
+                    PipelineStep::FunctionCall {
+                        name: func_name,
+                        args,
+                    } => {
+                        let mut call_args = vec![current_reg.clone()];
+                        for arg in args {
+                            let (arg_reg, arg_instrs) = generate_expr_ir(arg);
+                            instructions.extend(arg_instrs);
+                            call_args.push(arg_reg);
+                        }
                         let result_reg = format!("t{}", instructions.len());
                         instructions.push(IrInstruction::Call {
                             func_name: func_name.clone(),
-                            args: vec![current_reg.clone()],
+                            args: call_args,
                             target: result_reg.clone(),
                         });
                         current_reg = result_reg;
@@ -169,7 +192,10 @@ mod tests {
             name: "result".to_string(),
             expr: Expr::Pipeline {
                 initial: Box::new(Expr::Literal(Literal::Integer(10))),
-                steps: vec![PipelineStep::FunctionCall("double".to_string())],
+                steps: vec![PipelineStep::FunctionCall {
+                    name: "double".to_string(),
+                    args: vec![],
+                }],
             },
         };
 
@@ -266,8 +292,14 @@ mod tests {
             expr: Expr::Pipeline {
                 initial: Box::new(Expr::Literal(Literal::Integer(10))),
                 steps: vec![
-                    PipelineStep::FunctionCall("double".to_string()),
-                    PipelineStep::FunctionCall("increment".to_string()),
+                    PipelineStep::FunctionCall {
+                        name: "double".to_string(),
+                        args: vec![],
+                    },
+                    PipelineStep::FunctionCall {
+                        name: "increment".to_string(),
+                        args: vec![],
+                    },
                 ],
             },
         };
@@ -286,5 +318,60 @@ mod tests {
             call_count, 2,
             "Expected 2 Call instructions for 2 pipeline steps"
         );
+    }
+
+    #[test]
+    fn test_generate_ir_for_function_simple() {
+        let stmt = Stmt::FunctionDefinition {
+            name: "add".to_string(),
+            is_exported: false,
+            params: vec![
+                ("a".to_string(), crate::ast::Type::Simple("Int".to_string())),
+                ("b".to_string(), crate::ast::Type::Simple("Int".to_string())),
+            ],
+            return_type: crate::ast::Type::Simple("Int".to_string()),
+            body: Box::new(Expr::Literal(Literal::Integer(42))),
+        };
+
+        let ir_func = generate_ir_for_function(&stmt).unwrap();
+
+        assert_eq!(ir_func.name, "add");
+        assert!(!ir_func.is_exported);
+        assert_eq!(ir_func.params.len(), 2);
+        assert_eq!(ir_func.block.label, Some("entry".to_string()));
+        assert!(ir_func.block.instructions.len() >= 2);
+        assert!(matches!(
+            ir_func.block.instructions.last(),
+            Some(IrInstruction::Return { .. })
+        ));
+    }
+
+    #[test]
+    fn test_generate_ir_for_function_with_pipeline() {
+        let stmt = Stmt::FunctionDefinition {
+            name: "greet".to_string(),
+            is_exported: false,
+            params: vec![(
+                "name".to_string(),
+                crate::ast::Type::Simple("String".to_string()),
+            )],
+            return_type: crate::ast::Type::Simple("String".to_string()),
+            body: Box::new(Expr::Pipeline {
+                initial: Box::new(Expr::Literal(Literal::String("Hello".to_string()))),
+                steps: vec![PipelineStep::FunctionCall {
+                    name: "concat".to_string(),
+                    args: vec![Expr::Identifier("name".to_string())],
+                }],
+            }),
+        };
+
+        let ir_func = generate_ir_for_function(&stmt).unwrap();
+
+        assert_eq!(ir_func.name, "greet");
+        assert!(ir_func.block.instructions.len() >= 3);
+        assert!(matches!(
+            ir_func.block.instructions.last(),
+            Some(IrInstruction::Return { .. })
+        ));
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -118,7 +118,31 @@ impl Parser {
             return self.parse_match();
         }
 
-        let initial = self.parse_term()?;
+        self.parse_binary_op()
+    }
+
+    fn parse_binary_op(&mut self) -> Result<Expr, String> {
+        let mut left = self.parse_term()?;
+
+        while matches!(
+            self.peek().kind,
+            TokenKind::Plus | TokenKind::Minus | TokenKind::Star | TokenKind::Slash
+        ) {
+            let op = match self.peek().kind {
+                TokenKind::Plus => crate::ast::BinaryOp::Add,
+                TokenKind::Minus => crate::ast::BinaryOp::Sub,
+                TokenKind::Star => crate::ast::BinaryOp::Mul,
+                TokenKind::Slash => crate::ast::BinaryOp::Div,
+                _ => unreachable!(),
+            };
+            self.advance();
+            let right = self.parse_term()?;
+            left = Expr::BinaryOp {
+                left: Box::new(left),
+                op,
+                right: Box::new(right),
+            };
+        }
 
         let mut steps = Vec::new();
 
@@ -133,8 +157,18 @@ impl Parser {
                     } else if let TokenKind::Identifier(name) = self.peek().kind.clone() {
                         self.advance();
                         self.consume(TokenKind::LParen, "expected '('")?;
+                        let mut args = Vec::new();
+                        if self.peek().kind != TokenKind::RParen {
+                            loop {
+                                let arg = self.parse_expression()?;
+                                args.push(arg);
+                                if !self.match_token(TokenKind::Comma) {
+                                    break;
+                                }
+                            }
+                        }
                         self.consume(TokenKind::RParen, "expected ')'")?;
-                        steps.push(PipelineStep::FunctionCall(name));
+                        steps.push(PipelineStep::FunctionCall { name, args });
                     } else if matches!(
                         self.peek().kind,
                         TokenKind::Plus | TokenKind::Minus | TokenKind::Star | TokenKind::Slash
@@ -203,10 +237,10 @@ impl Parser {
         }
 
         if steps.is_empty() {
-            Ok(initial)
+            Ok(left)
         } else {
             Ok(Expr::Pipeline {
-                initial: Box::new(initial),
+                initial: Box::new(left),
                 steps,
             })
         }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -110,7 +110,7 @@ fn test_function_definition_expression_style() {
             is_exported,
             params,
             return_type,
-            body,
+            body: _,
         } => {
             assert_eq!(name, "add");
             assert!(!*is_exported);
@@ -139,7 +139,7 @@ fn test_function_definition_with_pipeline() {
             is_exported,
             params,
             return_type,
-            body,
+            body: _,
         } => {
             assert_eq!(name, "greet");
             assert!(!*is_exported);
@@ -167,7 +167,7 @@ fn test_function_definition_literal() {
             is_exported,
             params,
             return_type,
-            body,
+            body: _,
         } => {
             assert_eq!(name, "get_constant");
             assert!(!*is_exported);

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -93,3 +93,87 @@ fn test_match_keyword_tokenization() {
         crate::lexer::TokenKind::Identifier("value".to_string())
     );
 }
+
+#[test]
+fn test_function_definition_expression_style() {
+    let code = "fn add(a: Int, b: Int) -> Int =: a + b";
+    let mut lexer = Lexer::new(code);
+    let tokens = lexer.tokenize();
+    let mut parser = Parser::new(tokens);
+    let result = parser.parse();
+    assert!(result.is_ok());
+    let stmts = result.unwrap();
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0] {
+        crate::ast::Stmt::FunctionDefinition {
+            name,
+            is_exported,
+            params,
+            return_type,
+            body,
+        } => {
+            assert_eq!(name, "add");
+            assert!(!*is_exported);
+            assert_eq!(params.len(), 2);
+            assert_eq!(params[0].0, "a");
+            assert_eq!(params[1].0, "b");
+            assert!(matches!(return_type.normalize(), crate::ast::Type::Int));
+        }
+        _ => panic!("Expected FunctionDefinition"),
+    }
+}
+
+#[test]
+fn test_function_definition_with_pipeline() {
+    let code = r#"fn greet(name: String) -> String =: "Hello, " :: concat(name)"#;
+    let mut lexer = Lexer::new(code);
+    let tokens = lexer.tokenize();
+    let mut parser = Parser::new(tokens);
+    let result = parser.parse();
+    assert!(result.is_ok());
+    let stmts = result.unwrap();
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0] {
+        crate::ast::Stmt::FunctionDefinition {
+            name,
+            is_exported,
+            params,
+            return_type,
+            body,
+        } => {
+            assert_eq!(name, "greet");
+            assert!(!*is_exported);
+            assert_eq!(params.len(), 1);
+            assert_eq!(params[0].0, "name");
+            assert!(matches!(return_type.normalize(), crate::ast::Type::String));
+        }
+        _ => panic!("Expected FunctionDefinition"),
+    }
+}
+
+#[test]
+fn test_function_definition_literal() {
+    let code = "fn get_constant() -> Int =: 42";
+    let mut lexer = Lexer::new(code);
+    let tokens = lexer.tokenize();
+    let mut parser = Parser::new(tokens);
+    let result = parser.parse();
+    assert!(result.is_ok());
+    let stmts = result.unwrap();
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0] {
+        crate::ast::Stmt::FunctionDefinition {
+            name,
+            is_exported,
+            params,
+            return_type,
+            body,
+        } => {
+            assert_eq!(name, "get_constant");
+            assert!(!*is_exported);
+            assert_eq!(params.len(), 0);
+            assert!(matches!(return_type.normalize(), crate::ast::Type::Int));
+        }
+        _ => panic!("Expected FunctionDefinition"),
+    }
+}


### PR DESCRIPTION
Implement Expression Body (=: expression) syntax for Iris functions as per IRIS_SPEC.md.

## Summary
- Update IRIS_SPEC.md to formally define Expression Style (=: expression) for functions
- Extend AST to support binary operations and function calls with arguments in pipelines  
- Modify parser to handle binary ops and pipeline function calls with args
- Update type checker to validate expression bodies and pipeline calls
- Implement IR generation for binary ops and function calls in expressions
- Add comprehensive test cases for expression body syntax

## Test Cases Verified
-  (binary operations)
-  (pipeline with args)
-  (literal expressions)

Closes #9